### PR TITLE
v1.11 Improve permission management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
  "partial_derive2",
  "periphery_client",
  "rand",
+ "regex",
  "reqwest 0.12.5",
  "resolver_api",
  "run_command",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "alerter"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "command"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "monitor_client",
  "run_command",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "formatting"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "serror",
 ]
@@ -1482,7 +1482,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "command",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "logger"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "monitor_client",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "migrator"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "monitor_cli"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "monitor_client"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "monitor_core"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "monitor_periphery"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "async_timing_util",
@@ -2839,7 +2839,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "periphery_client"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "monitor_client",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "dotenv",
@@ -4580,7 +4580,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_logger"
-version = "1.10.5"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,5 +103,6 @@ derive_builder = "0.20.0"
 typeshare = "1.0.3"
 octorust = "0.7.0"
 colored = "2.1.0"
+regex = "1.10.5"
 bson = "2.11.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ monitor_client = { path = "client/core/rs" }
 
 [workspace.dependencies]
 # LOCAL
-monitor_client = "1.10.5"
+monitor_client = "1.11.0"
 periphery_client = { path = "client/periphery/rs" }
 formatting = { path = "lib/formatting" }
 command = { path = "lib/command" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["bin/*", "lib/*", "client/core/rs", "client/periphery/rs"]
 
 [workspace.package]
-version = "1.10.5"
+version = "1.11.0"
 edition = "2021"
 authors = ["mbecker20 <becker.maxh@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/bin/core/Cargo.toml
+++ b/bin/core/Cargo.toml
@@ -58,6 +58,7 @@ tokio.workspace = true
 tower.workspace = true
 serde.workspace = true
 strum.workspace = true
+regex.workspace = true
 axum.workspace = true
 toml.workspace = true
 uuid.workspace = true

--- a/bin/core/src/api/read/alert.rs
+++ b/bin/core/src/api/read/alert.rs
@@ -14,7 +14,7 @@ use resolver_api::Resolve;
 
 use crate::{
   config::core_config,
-  helpers::query::get_resource_ids_for_non_admin,
+  helpers::query::get_resource_ids_for_user,
   state::{db_client, State},
 };
 
@@ -28,13 +28,13 @@ impl Resolve<ListAlerts, User> for State {
   ) -> anyhow::Result<ListAlertsResponse> {
     let mut query = query.unwrap_or_default();
     if !user.admin && !core_config().transparent_mode {
-      let server_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let server_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Server,
       )
       .await?;
-      let deployment_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let deployment_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Deployment,
       )
       .await?;

--- a/bin/core/src/api/read/alerter.rs
+++ b/bin/core/src/api/read/alerter.rs
@@ -67,15 +67,9 @@ impl Resolve<GetAlertersSummary, User> for State {
     )
     .await?
     {
-      Some(ids) => {
-        let ids = ids
-          .into_iter()
-          .flat_map(|id| ObjectId::from_str(&id))
-          .collect::<Vec<_>>();
-        doc! {
-          "_id": { "$in": ids }
-        }
-      }
+      Some(ids) => doc! {
+        "_id": { "$in": ids }
+      },
       None => Document::new(),
     };
     let total = db_client()

--- a/bin/core/src/api/read/alerter.rs
+++ b/bin/core/src/api/read/alerter.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::Context;
 use mongo_indexed::Document;
 use monitor_client::{
@@ -11,7 +9,7 @@ use monitor_client::{
     user::User,
   },
 };
-use mungos::mongodb::bson::{doc, oid::ObjectId};
+use mungos::mongodb::bson::doc;
 use resolver_api::Resolve;
 
 use crate::{

--- a/bin/core/src/api/read/builder.rs
+++ b/bin/core/src/api/read/builder.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr};
+use std::collections::HashSet;
 
 use anyhow::Context;
 use mongo_indexed::Document;
@@ -11,7 +11,7 @@ use monitor_client::{
     user::User,
   },
 };
-use mungos::mongodb::bson::{doc, oid::ObjectId};
+use mungos::mongodb::bson::doc;
 use resolver_api::Resolve;
 
 use crate::{

--- a/bin/core/src/api/read/builder.rs
+++ b/bin/core/src/api/read/builder.rs
@@ -68,15 +68,9 @@ impl Resolve<GetBuildersSummary, User> for State {
     )
     .await?
     {
-      Some(ids) => {
-        let ids = ids
-          .into_iter()
-          .flat_map(|id| ObjectId::from_str(&id))
-          .collect::<Vec<_>>();
-        doc! {
-          "_id": { "$in": ids }
-        }
-      }
+      Some(ids) => doc! {
+        "_id": { "$in": ids }
+      },
       None => Document::new(),
     };
     let total = db_client()

--- a/bin/core/src/api/read/mod.rs
+++ b/bin/core/src/api/read/mod.rs
@@ -47,6 +47,7 @@ enum ReadRequest {
   // ==== USER ====
   GetUsername(GetUsername),
   GetPermissionLevel(GetPermissionLevel),
+  FindUser(FindUser),
   ListUsers(ListUsers),
   ListApiKeys(ListApiKeys),
   ListApiKeysForServiceUser(ListApiKeysForServiceUser),

--- a/bin/core/src/api/read/permission.rs
+++ b/bin/core/src/api/read/permission.rs
@@ -44,7 +44,7 @@ impl Resolve<GetPermissionLevel, User> for State {
       return Ok(PermissionLevel::Write);
     }
     let (variant, id) = target.extract_variant_id();
-    get_user_permission_on_resource(&user.id, variant, id).await
+    get_user_permission_on_resource(&user, variant, id).await
   }
 }
 

--- a/bin/core/src/api/read/server_template.rs
+++ b/bin/core/src/api/read/server_template.rs
@@ -65,15 +65,9 @@ impl Resolve<GetServerTemplatesSummary, User> for State {
     )
     .await?
     {
-      Some(ids) => {
-        let ids = ids
-          .into_iter()
-          .flat_map(|id| ObjectId::from_str(&id))
-          .collect::<Vec<_>>();
-        doc! {
-          "_id": { "$in": ids }
-        }
-      }
+      Some(ids) => doc! {
+        "_id": { "$in": ids }
+      },
       None => Document::new(),
     };
     let total = db_client()

--- a/bin/core/src/api/read/server_template.rs
+++ b/bin/core/src/api/read/server_template.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::Context;
 use mongo_indexed::Document;
 use monitor_client::{
@@ -9,7 +7,7 @@ use monitor_client::{
     update::ResourceTargetVariant, user::User,
   },
 };
-use mungos::mongodb::bson::{doc, oid::ObjectId};
+use mungos::mongodb::bson::doc;
 use resolver_api::Resolve;
 
 use crate::{

--- a/bin/core/src/api/read/server_template.rs
+++ b/bin/core/src/api/read/server_template.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::Context;
+use mongo_indexed::Document;
 use monitor_client::{
   api::read::*,
   entities::{
@@ -12,7 +13,7 @@ use mungos::mongodb::bson::{doc, oid::ObjectId};
 use resolver_api::Resolve;
 
 use crate::{
-  helpers::query::get_resource_ids_for_non_admin,
+  helpers::query::get_resource_ids_for_user,
   resource,
   state::{db_client, State},
 };
@@ -58,26 +59,27 @@ impl Resolve<GetServerTemplatesSummary, User> for State {
     GetServerTemplatesSummary {}: GetServerTemplatesSummary,
     user: User,
   ) -> anyhow::Result<GetServerTemplatesSummaryResponse> {
-    let query = if user.admin {
-      None
-    } else {
-      let ids = get_resource_ids_for_non_admin(
-        &user.id,
-        ResourceTargetVariant::ServerTemplate,
-      )
-      .await?
-      .into_iter()
-      .flat_map(|id| ObjectId::from_str(&id))
-      .collect::<Vec<_>>();
-      let query = doc! {
-        "_id": { "$in": ids }
-      };
-      Some(query)
+    let query = match get_resource_ids_for_user(
+      &user,
+      ResourceTargetVariant::ServerTemplate,
+    )
+    .await?
+    {
+      Some(ids) => {
+        let ids = ids
+          .into_iter()
+          .flat_map(|id| ObjectId::from_str(&id))
+          .collect::<Vec<_>>();
+        doc! {
+          "_id": { "$in": ids }
+        }
+      }
+      None => Document::new(),
     };
     let total = db_client()
       .await
       .server_templates
-      .count_documents(query.unwrap_or_default())
+      .count_documents(query)
       .await
       .context("failed to count all server template documents")?;
     let res = GetServerTemplatesSummaryResponse {

--- a/bin/core/src/api/read/toml.rs
+++ b/bin/core/src/api/read/toml.rs
@@ -573,6 +573,7 @@ async fn add_user_groups(
         .into_iter()
         .filter_map(|user_id| usernames.get(&user_id).cloned())
         .collect(),
+      all: ug.all,
       permissions,
     });
   }

--- a/bin/core/src/api/read/update.rs
+++ b/bin/core/src/api/read/update.rs
@@ -29,7 +29,7 @@ use resolver_api::Resolve;
 
 use crate::{
   config::core_config,
-  helpers::query::get_resource_ids_for_non_admin,
+  helpers::query::get_resource_ids_for_user,
   resource,
   state::{db_client, State},
 };
@@ -45,43 +45,41 @@ impl Resolve<ListUpdates, User> for State {
     let query = if user.admin || core_config().transparent_mode {
       query
     } else {
-      let server_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let server_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Server,
       )
       .await?;
-      let deployment_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let deployment_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Deployment,
       )
       .await?;
-      let build_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let build_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Build,
       )
       .await?;
-      let repo_ids = get_resource_ids_for_non_admin(
-        &user.id,
-        ResourceTargetVariant::Repo,
-      )
-      .await?;
-      let procedure_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let repo_ids =
+        get_resource_ids_for_user(&user, ResourceTargetVariant::Repo)
+          .await?;
+      let procedure_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Procedure,
       )
       .await?;
-      let builder_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let builder_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Builder,
       )
       .await?;
-      let alerter_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let alerter_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::Alerter,
       )
       .await?;
-      let server_template_ids = get_resource_ids_for_non_admin(
-        &user.id,
+      let server_template_ids = get_resource_ids_for_user(
+        &user,
         ResourceTargetVariant::ServerTemplate,
       )
       .await?;

--- a/bin/core/src/api/write/mod.rs
+++ b/bin/core/src/api/write/mod.rs
@@ -47,10 +47,10 @@ pub enum WriteRequest {
   AddUserToUserGroup(AddUserToUserGroup),
   RemoveUserFromUserGroup(RemoveUserFromUserGroup),
   SetUsersInUserGroup(SetUsersInUserGroup),
-  SetUserGroupResourceBasePermission(SetUserGroupResourceBasePermission),
 
   // ==== PERMISSIONS ====
   UpdateUserBasePermissions(UpdateUserBasePermissions),
+  UpdatePermissionOnResourceType(UpdatePermissionOnResourceType),
   UpdatePermissionOnTarget(UpdatePermissionOnTarget),
 
   // ==== DESCRIPTION ====

--- a/bin/core/src/api/write/mod.rs
+++ b/bin/core/src/api/write/mod.rs
@@ -47,6 +47,7 @@ pub enum WriteRequest {
   AddUserToUserGroup(AddUserToUserGroup),
   RemoveUserFromUserGroup(RemoveUserFromUserGroup),
   SetUsersInUserGroup(SetUsersInUserGroup),
+  SetUserGroupResourceBasePermission(SetUserGroupResourceBasePermission),
 
   // ==== PERMISSIONS ====
   UpdateUserBasePermissions(UpdateUserBasePermissions),

--- a/bin/core/src/api/write/service_user.rs
+++ b/bin/core/src/api/write/service_user.rs
@@ -52,7 +52,6 @@ impl Resolve<CreateServiceUser, User> for State {
       create_build_permissions: false,
       last_update_view: 0,
       recents: Default::default(),
-      all: Default::default(),
       updated_at: monitor_timestamp(),
     };
     user.id = db_client()

--- a/bin/core/src/api/write/service_user.rs
+++ b/bin/core/src/api/write/service_user.rs
@@ -52,6 +52,7 @@ impl Resolve<CreateServiceUser, User> for State {
       create_build_permissions: false,
       last_update_view: 0,
       recents: Default::default(),
+      all: Default::default(),
       updated_at: monitor_timestamp(),
     };
     user.id = db_client()

--- a/bin/core/src/api/write/service_user.rs
+++ b/bin/core/src/api/write/service_user.rs
@@ -51,11 +51,8 @@ impl Resolve<CreateServiceUser, User> for State {
       create_server_permissions: false,
       create_build_permissions: false,
       last_update_view: 0,
-      recent_servers: Vec::new(),
-      recent_deployments: Vec::new(),
-      recent_builds: Vec::new(),
-      recent_repos: Vec::new(),
-      recent_procedures: Vec::new(),
+      recents: Default::default(),
+      all: Default::default(),
       updated_at: monitor_timestamp(),
     };
     user.id = db_client()

--- a/bin/core/src/api/write/user_group.rs
+++ b/bin/core/src/api/write/user_group.rs
@@ -29,6 +29,7 @@ impl Resolve<CreateUserGroup, User> for State {
     let user_group = UserGroup {
       id: Default::default(),
       users: Default::default(),
+      all: Default::default(),
       updated_at: monitor_timestamp(),
       name,
     };

--- a/bin/core/src/api/write/user_group.rs
+++ b/bin/core/src/api/write/user_group.rs
@@ -4,8 +4,7 @@ use anyhow::{anyhow, Context};
 use monitor_client::{
   api::write::{
     AddUserToUserGroup, CreateUserGroup, DeleteUserGroup,
-    RemoveUserFromUserGroup, RenameUserGroup,
-    SetUserGroupResourceBasePermission, SetUsersInUserGroup,
+    RemoveUserFromUserGroup, RenameUserGroup, SetUsersInUserGroup,
   },
   entities::{monitor_timestamp, user::User, user_group::UserGroup},
 };
@@ -232,47 +231,6 @@ impl Resolve<SetUsersInUserGroup, User> for State {
       .update_one(filter.clone(), doc! { "$set": { "users": users } })
       .await
       .context("failed to set users on user group")?;
-    db.user_groups
-      .find_one(filter)
-      .await
-      .context("failed to query db for UserGroups")?
-      .context("no user group with given id")
-  }
-}
-
-impl Resolve<SetUserGroupResourceBasePermission, User> for State {
-  async fn resolve(
-    &self,
-    SetUserGroupResourceBasePermission {
-      user_group,
-      resource_type,
-      permission: level,
-    }: SetUserGroupResourceBasePermission,
-    admin: User,
-  ) -> anyhow::Result<UserGroup> {
-    if !admin.admin {
-      return Err(anyhow!("This call is admin-only"));
-    }
-
-    let filter = match ObjectId::from_str(&user_group) {
-      Ok(id) => doc! { "_id": id },
-      Err(_) => doc! { "name": &user_group },
-    };
-
-    let db = db_client().await;
-
-    db.user_groups
-      .update_one(
-        filter.clone(),
-        doc! {
-          "$set": {
-            format!("all.{resource_type}"): level.as_ref()
-          }
-        },
-      )
-      .await
-      .context("failed to set base permission on db")?;
-
     db.user_groups
       .find_one(filter)
       .await

--- a/bin/core/src/auth/github/mod.rs
+++ b/bin/core/src/auth/github/mod.rs
@@ -87,11 +87,8 @@ async fn callback(
         create_build_permissions: no_users_exist,
         updated_at: ts,
         last_update_view: 0,
-        recent_servers: Vec::new(),
-        recent_deployments: Vec::new(),
-        recent_builds: Vec::new(),
-        recent_repos: Vec::new(),
-        recent_procedures: Vec::new(),
+        all: Default::default(),
+        recents: Default::default(),
         config: UserConfig::Github {
           github_id,
           avatar: github_user.avatar_url,

--- a/bin/core/src/auth/github/mod.rs
+++ b/bin/core/src/auth/github/mod.rs
@@ -87,7 +87,6 @@ async fn callback(
         create_build_permissions: no_users_exist,
         updated_at: ts,
         last_update_view: 0,
-        all: Default::default(),
         recents: Default::default(),
         config: UserConfig::Github {
           github_id,

--- a/bin/core/src/auth/github/mod.rs
+++ b/bin/core/src/auth/github/mod.rs
@@ -88,6 +88,7 @@ async fn callback(
         updated_at: ts,
         last_update_view: 0,
         recents: Default::default(),
+        all: Default::default(),
         config: UserConfig::Github {
           github_id,
           avatar: github_user.avatar_url,

--- a/bin/core/src/auth/google/mod.rs
+++ b/bin/core/src/auth/google/mod.rs
@@ -102,7 +102,6 @@ async fn callback(
         create_build_permissions: no_users_exist,
         updated_at: ts,
         last_update_view: 0,
-        all: Default::default(),
         recents: Default::default(),
         config: UserConfig::Google {
           google_id,

--- a/bin/core/src/auth/google/mod.rs
+++ b/bin/core/src/auth/google/mod.rs
@@ -103,6 +103,7 @@ async fn callback(
         updated_at: ts,
         last_update_view: 0,
         recents: Default::default(),
+        all: Default::default(),
         config: UserConfig::Google {
           google_id,
           avatar: google_user.picture,

--- a/bin/core/src/auth/google/mod.rs
+++ b/bin/core/src/auth/google/mod.rs
@@ -102,11 +102,8 @@ async fn callback(
         create_build_permissions: no_users_exist,
         updated_at: ts,
         last_update_view: 0,
-        recent_servers: Vec::new(),
-        recent_deployments: Vec::new(),
-        recent_builds: Vec::new(),
-        recent_repos: Vec::new(),
-        recent_procedures: Vec::new(),
+        all: Default::default(),
+        recents: Default::default(),
         config: UserConfig::Google {
           google_id,
           avatar: google_user.picture,

--- a/bin/core/src/auth/local.rs
+++ b/bin/core/src/auth/local.rs
@@ -62,11 +62,8 @@ impl Resolve<CreateLocalUser, HeaderMap> for State {
       create_build_permissions: no_users_exist,
       updated_at: ts,
       last_update_view: 0,
-      recent_servers: Vec::new(),
-      recent_deployments: Vec::new(),
-      recent_builds: Vec::new(),
-      recent_repos: Vec::new(),
-      recent_procedures: Vec::new(),
+      all: Default::default(),
+      recents: Default::default(),
       config: UserConfig::Local { password },
     };
 

--- a/bin/core/src/auth/local.rs
+++ b/bin/core/src/auth/local.rs
@@ -63,6 +63,7 @@ impl Resolve<CreateLocalUser, HeaderMap> for State {
       updated_at: ts,
       last_update_view: 0,
       recents: Default::default(),
+      all: Default::default(),
       config: UserConfig::Local { password },
     };
 

--- a/bin/core/src/auth/local.rs
+++ b/bin/core/src/auth/local.rs
@@ -62,7 +62,6 @@ impl Resolve<CreateLocalUser, HeaderMap> for State {
       create_build_permissions: no_users_exist,
       updated_at: ts,
       last_update_view: 0,
-      all: Default::default(),
       recents: Default::default(),
       config: UserConfig::Local { password },
     };

--- a/bin/core/src/helpers/alert.rs
+++ b/bin/core/src/helpers/alert.rs
@@ -335,7 +335,7 @@ async fn send_slack_alert(
     }
     AlertData::ResourceSyncPendingUpdates { id, name } => {
       let text =
-        format!("{level} | There are pending resource sync updates");
+        format!("{level} | Pending resource sync updates on {name}");
       let blocks = vec![
         Block::header(text.clone()),
         Block::section(format!(

--- a/bin/core/src/helpers/sync/user_groups.rs
+++ b/bin/core/src/helpers/sync/user_groups.rs
@@ -546,6 +546,12 @@ pub async fn get_updates_for_execution(
     let update_permissions =
       user_group.permissions != original_permissions;
 
+    // remove any permissions that already exist on original 
+    user_group.permissions.retain(|permission| {
+      // only keep it if its NOT in original
+      !original_permissions.contains(permission)
+    });
+
     // Extend permissions with any existing that have no target in incoming
     let to_remove = original_permissions
       .into_iter()

--- a/bin/core/src/helpers/sync/user_groups.rs
+++ b/bin/core/src/helpers/sync/user_groups.rs
@@ -859,8 +859,8 @@ async fn expand_user_group_permissions(
     if id.is_empty() {
       continue;
     }
-    if id.starts_with("$reg|") && id.ends_with('|') {
-      let inner = &id[5..(id.len() - 1)];
+    if id.starts_with('\\') && id.ends_with('\\') {
+      let inner = &id[1..(id.len() - 1)];
       let regex = Regex::new(inner)
         .with_context(|| format!("invalid regex. got: {inner}"))?;
       match variant {

--- a/bin/core/src/helpers/sync/user_groups.rs
+++ b/bin/core/src/helpers/sync/user_groups.rs
@@ -6,9 +6,8 @@ use monitor_client::{
   api::{
     read::ListUserTargetPermissions,
     write::{
-      CreateUserGroup, DeleteUserGroup,
-      SetUserGroupResourceBasePermission, SetUsersInUserGroup,
-      UpdatePermissionOnTarget,
+      CreateUserGroup, DeleteUserGroup, SetUsersInUserGroup,
+      UpdatePermissionOnResourceType, UpdatePermissionOnTarget,
     },
   },
   entities::{
@@ -783,8 +782,8 @@ async fn run_update_all(
   for (resource_type, permission) in all_diff {
     if let Err(e) = State
       .resolve(
-        SetUserGroupResourceBasePermission {
-          user_group: user_group.clone(),
+        UpdatePermissionOnResourceType {
+          user_target: UserTarget::UserGroup(user_group.clone()),
           resource_type,
           permission,
         },

--- a/bin/core/src/resource/mod.rs
+++ b/bin/core/src/resource/mod.rs
@@ -268,10 +268,6 @@ async fn list_full_for_user_using_document<T: MonitorResource>(
   if let Some(ids) =
     get_resource_ids_for_user(user, T::resource_type()).await?
   {
-    let ids = ids
-      .into_iter()
-      .flat_map(|id| ObjectId::from_str(&id))
-      .collect::<Vec<_>>();
     filters.insert("_id", doc! { "$in": ids });
   }
   find_collect(

--- a/bin/core/src/resource/mod.rs
+++ b/bin/core/src/resource/mod.rs
@@ -33,7 +33,7 @@ use crate::{
   helpers::{
     create_permission, flatten_document,
     query::{
-      get_resource_ids_for_non_admin, get_tag,
+      get_resource_ids_for_user, get_tag,
       get_user_permission_on_resource, id_or_name_filter,
     },
     update::{add_update, make_update},
@@ -211,7 +211,7 @@ pub async fn get_check_permissions<T: MonitorResource>(
     return Ok(resource);
   }
   let permissions = get_user_permission_on_resource(
-    &user.id,
+    user,
     T::resource_type(),
     &resource.id,
   )
@@ -265,13 +265,13 @@ async fn list_full_for_user_using_document<T: MonitorResource>(
   mut filters: Document,
   user: &User,
 ) -> anyhow::Result<Vec<Resource<T::Config, T::Info>>> {
-  if !user.admin && !core_config().transparent_mode {
-    let ids =
-      get_resource_ids_for_non_admin(&user.id, T::resource_type())
-        .await?
-        .into_iter()
-        .flat_map(|id| ObjectId::from_str(&id))
-        .collect::<Vec<_>>();
+  if let Some(ids) =
+    get_resource_ids_for_user(user, T::resource_type()).await?
+  {
+    let ids = ids
+      .into_iter()
+      .flat_map(|id| ObjectId::from_str(&id))
+      .collect::<Vec<_>>();
     filters.insert("_id", doc! { "$in": ids });
   }
   find_collect(

--- a/bin/core/src/ws.rs
+++ b/bin/core/src/ws.rs
@@ -208,7 +208,7 @@ async fn user_can_see_update(
   }
   let (variant, id) = update_target.extract_variant_id();
   let permissions =
-    get_user_permission_on_resource(&user.id, variant, id).await?;
+    get_user_permission_on_resource(user, variant, id).await?;
   if permissions > PermissionLevel::None {
     Ok(())
   } else {

--- a/bin/migrator/src/legacy/v0/user.rs
+++ b/bin/migrator/src/legacy/v0/user.rs
@@ -106,11 +106,8 @@ impl TryFrom<User> for monitor_client::entities::user::User {
       create_server_permissions: value.create_server_permissions,
       create_build_permissions: value.create_build_permissions,
       last_update_view: Default::default(),
-      recent_servers: Vec::new(),
-      recent_deployments: Vec::new(),
-      recent_builds: Vec::new(),
-      recent_repos: Vec::new(),
-      recent_procedures: Vec::new(),
+      all: Default::default(),
+      recents: Default::default(),
       updated_at: unix_from_monitor_ts(&value.updated_at)?,
     };
     Ok(user)

--- a/bin/migrator/src/legacy/v0/user.rs
+++ b/bin/migrator/src/legacy/v0/user.rs
@@ -106,7 +106,6 @@ impl TryFrom<User> for monitor_client::entities::user::User {
       create_server_permissions: value.create_server_permissions,
       create_build_permissions: value.create_build_permissions,
       last_update_view: Default::default(),
-      all: Default::default(),
       recents: Default::default(),
       updated_at: unix_from_monitor_ts(&value.updated_at)?,
     };

--- a/bin/migrator/src/legacy/v0/user.rs
+++ b/bin/migrator/src/legacy/v0/user.rs
@@ -107,6 +107,7 @@ impl TryFrom<User> for monitor_client::entities::user::User {
       create_build_permissions: value.create_build_permissions,
       last_update_view: Default::default(),
       recents: Default::default(),
+      all: Default::default(),
       updated_at: unix_from_monitor_ts(&value.updated_at)?,
     };
     Ok(user)

--- a/client/core/rs/src/api/read/user.rs
+++ b/client/core/rs/src/api/read/user.rs
@@ -22,8 +22,8 @@ pub type ListApiKeysResponse = Vec<ApiKey>;
 
 //
 
-/// Gets list of api keys for the user at ID.
 /// **Admin only.**
+/// Gets list of api keys for the user.
 /// Will still fail if you call for a user_id that isn't a service user.
 /// Response: [ListApiKeysForServiceUserResponse]
 #[typeshare]
@@ -33,8 +33,9 @@ pub type ListApiKeysResponse = Vec<ApiKey>;
 #[empty_traits(MonitorReadRequest)]
 #[response(ListApiKeysForServiceUserResponse)]
 pub struct ListApiKeysForServiceUser {
-  /// The id of the user.
-  pub user_id: String,
+  /// Id or username
+  #[serde(alias = "id", alias = "username")]
+  pub user: String,
 }
 
 #[typeshare]
@@ -42,8 +43,28 @@ pub type ListApiKeysForServiceUserResponse = Vec<ApiKey>;
 
 //
 
-/// Gets list of monitor users.
 /// **Admin only.**
+/// Find a user.
+/// Response: [FindUserResponse]
+#[typeshare]
+#[derive(
+  Serialize, Deserialize, Debug, Clone, Default, Request, EmptyTraits,
+)]
+#[empty_traits(MonitorReadRequest)]
+#[response(FindUserResponse)]
+pub struct FindUser {
+  /// Id or username
+  #[serde(alias = "id", alias = "username")]
+  pub user: String,
+}
+
+#[typeshare]
+pub type FindUserResponse = User;
+
+//
+
+/// **Admin only.**
+/// Gets list of monitor users.
 /// Response: [ListUsersResponse]
 #[typeshare]
 #[derive(

--- a/client/core/rs/src/api/write/permissions.rs
+++ b/client/core/rs/src/api/write/permissions.rs
@@ -5,13 +5,13 @@ use typeshare::typeshare;
 
 use crate::entities::{
   permission::{PermissionLevel, UserTarget},
-  update::ResourceTarget,
+  update::{ResourceTarget, ResourceTargetVariant},
   NoData,
 };
 
 use super::MonitorWriteRequest;
 
-/// Update a user or user groups permission on a resource.
+/// **Admin only.** Update a user or user groups permission on a resource.
 /// Response: [NoData].
 #[typeshare]
 #[derive(
@@ -33,7 +33,29 @@ pub type UpdatePermissionOnTargetResponse = NoData;
 
 //
 
-/// Update a user's "base" permissions, eg. "enabled".
+/// **Admin only.** Update a user or user groups base permission level on a resource type.
+/// Response: [NoData].
+#[typeshare]
+#[derive(
+  Serialize, Deserialize, Debug, Clone, Request, EmptyTraits,
+)]
+#[empty_traits(MonitorWriteRequest)]
+#[response(UpdatePermissionOnResourceTypeResponse)]
+pub struct UpdatePermissionOnResourceType {
+  /// Specify the user or user group.
+  pub user_target: UserTarget,
+  /// The resource type: eg. Server, Build, Deployment, etc.
+  pub resource_type: ResourceTargetVariant,
+  /// The base permission level.
+  pub permission: PermissionLevel,
+}
+
+#[typeshare]
+pub type UpdatePermissionOnResourceTypeResponse = NoData;
+
+//
+
+/// **Admin only.** Update a user's "base" permissions, eg. "enabled".
 /// Response: [NoData].
 #[typeshare]
 #[derive(

--- a/client/core/rs/src/api/write/user_group.rs
+++ b/client/core/rs/src/api/write/user_group.rs
@@ -3,7 +3,10 @@ use resolver_api::derive::Request;
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
-use crate::entities::user_group::UserGroup;
+use crate::entities::{
+  permission::PermissionLevel, update::ResourceTargetVariant,
+  user_group::UserGroup,
+};
 
 use super::MonitorWriteRequest;
 
@@ -96,4 +99,21 @@ pub struct SetUsersInUserGroup {
   pub user_group: String,
   /// The user ids or usernames to hard set as the group's users.
   pub users: Vec<String>,
+}
+
+/// **Admin only.** Set the user group base permission levels on resource type
+/// Response: [UserGroup]
+#[typeshare]
+#[derive(
+  Serialize, Deserialize, Debug, Clone, Request, EmptyTraits,
+)]
+#[empty_traits(MonitorWriteRequest)]
+#[response(UserGroup)]
+pub struct SetUserGroupResourceBasePermission {
+  /// Id or name.
+  pub user_group: String,
+  /// The resource type: eg. Server, Build, Deployment, etc.
+  pub resource_type: ResourceTargetVariant,
+  /// The base permission level.
+  pub permission: PermissionLevel,
 }

--- a/client/core/rs/src/api/write/user_group.rs
+++ b/client/core/rs/src/api/write/user_group.rs
@@ -3,10 +3,7 @@ use resolver_api::derive::Request;
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
-use crate::entities::{
-  permission::PermissionLevel, update::ResourceTargetVariant,
-  user_group::UserGroup,
-};
+use crate::entities::user_group::UserGroup;
 
 use super::MonitorWriteRequest;
 
@@ -99,21 +96,4 @@ pub struct SetUsersInUserGroup {
   pub user_group: String,
   /// The user ids or usernames to hard set as the group's users.
   pub users: Vec<String>,
-}
-
-/// **Admin only.** Set the user group base permission levels on resource type
-/// Response: [UserGroup]
-#[typeshare]
-#[derive(
-  Serialize, Deserialize, Debug, Clone, Request, EmptyTraits,
-)]
-#[empty_traits(MonitorWriteRequest)]
-#[response(UserGroup)]
-pub struct SetUserGroupResourceBasePermission {
-  /// Id or name.
-  pub user_group: String,
-  /// The resource type: eg. Server, Build, Deployment, etc.
-  pub resource_type: ResourceTargetVariant,
-  /// The base permission level.
-  pub permission: PermissionLevel,
 }

--- a/client/core/rs/src/entities/toml.rs
+++ b/client/core/rs/src/entities/toml.rs
@@ -152,7 +152,7 @@ pub struct UserGroupToml {
 pub struct PermissionToml {
   /// Id can be:
   ///   - resource name. `id = "abcd-build"`
-  ///   - regex matching resource names. `id = "$reg|^(.+)-build-([0-9]+)$|"`
+  ///   - regex matching resource names. `id = "\^(.+)-build-([0-9]+)$\"`
   pub target: ResourceTarget,
 
   /// The permission level:

--- a/client/core/rs/src/entities/toml.rs
+++ b/client/core/rs/src/entities/toml.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -6,7 +8,7 @@ use super::{
   permission::PermissionLevel, procedure::PartialProcedureConfig,
   repo::PartialRepoConfig, server::PartialServerConfig,
   server_template::PartialServerTemplateConfig,
-  sync::PartialResourceSyncConfig, update::ResourceTarget,
+  sync::PartialResourceSyncConfig, update::{ResourceTarget, ResourceTargetVariant},
   variable::Variable,
 };
 
@@ -137,13 +139,26 @@ pub struct UserGroupToml {
   #[serde(default)]
   pub users: Vec<String>,
 
+  /// Give the user group elevated permissions on all resources of a certain type
+  #[serde(default)]
+  pub all: HashMap<ResourceTargetVariant, PermissionLevel>,
+
   /// Permissions given to the group
-  #[serde(default, rename = "permission")]
+  #[serde(default, alias = "permission")]
   pub permissions: Vec<PermissionToml>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PermissionToml {
+  /// Id can be:
+  ///   - resource name. `id = "abcd-build"`
+  ///   - regex matching resource names. `id = "$reg|^(.+)-build-([0-9]+)$|"`
   pub target: ResourceTarget,
+
+  /// The permission level:
+  ///   - None
+  ///   - Read
+  ///   - Execute
+  ///   - Write
   pub level: PermissionLevel,
 }

--- a/client/core/rs/src/entities/update.rs
+++ b/client/core/rs/src/entities/update.rs
@@ -187,19 +187,17 @@ impl Log {
 
 /// Used to reference a specific resource across all resource types
 #[typeshare]
-#[derive(
-  Serialize,
-  Deserialize,
+#[derive( 
   Debug,
   Clone,
   PartialEq,
   Eq,
   Hash,
+  Serialize,
+  Deserialize,
   EnumVariants,
 )]
 #[variant_derive(
-  Serialize,
-  Deserialize,
   Debug,
   Clone,
   Copy,
@@ -207,6 +205,9 @@ impl Log {
   Eq,
   PartialOrd,
   Ord,
+  Hash,
+  Serialize,
+  Deserialize,
   Display,
   EnumString,
   AsRefStr
@@ -214,14 +215,23 @@ impl Log {
 #[serde(tag = "type", content = "id")]
 pub enum ResourceTarget {
   System(String),
+  #[variant_attr(serde(alias = "builds"))]
   Build(String),
+  #[variant_attr(serde(alias = "builders"))]
   Builder(String),
+  #[variant_attr(serde(alias = "deployments"))]
   Deployment(String),
+  #[variant_attr(serde(alias = "servers"))]
   Server(String),
+  #[variant_attr(serde(alias = "repos"))]
   Repo(String),
+  #[variant_attr(serde(alias = "alerters"))]
   Alerter(String),
+  #[variant_attr(serde(alias = "procedures"))]
   Procedure(String),
+  #[variant_attr(serde(alias = "templates"))]
   ServerTemplate(String),
+  #[variant_attr(serde(alias = "syncs"))]
   ResourceSync(String),
 }
 

--- a/client/core/rs/src/entities/update.rs
+++ b/client/core/rs/src/entities/update.rs
@@ -216,23 +216,14 @@ impl Log {
 #[serde(tag = "type", content = "id")]
 pub enum ResourceTarget {
   System(String),
-  #[variant_attr(serde(alias = "builds"))]
   Build(String),
-  #[variant_attr(serde(alias = "builders"))]
   Builder(String),
-  #[variant_attr(serde(alias = "deployments"))]
   Deployment(String),
-  #[variant_attr(serde(alias = "servers"))]
   Server(String),
-  #[variant_attr(serde(alias = "repos"))]
   Repo(String),
-  #[variant_attr(serde(alias = "alerters"))]
   Alerter(String),
-  #[variant_attr(serde(alias = "procedures"))]
   Procedure(String),
-  #[variant_attr(serde(alias = "templates"))]
   ServerTemplate(String),
-  #[variant_attr(serde(alias = "syncs"))]
   ResourceSync(String),
 }
 

--- a/client/core/rs/src/entities/update.rs
+++ b/client/core/rs/src/entities/update.rs
@@ -11,7 +11,8 @@ use crate::entities::{
 use super::{
   alerter::Alerter, build::Build, builder::Builder,
   deployment::Deployment, procedure::Procedure, repo::Repo,
-  server::Server, server_template::ServerTemplate, Version,
+  server::Server, server_template::ServerTemplate,
+  sync::ResourceSync, Version,
 };
 
 /// Represents an action performed by Monitor.
@@ -187,7 +188,7 @@ impl Log {
 
 /// Used to reference a specific resource across all resource types
 #[typeshare]
-#[derive( 
+#[derive(
   Debug,
   Clone,
   PartialEq,
@@ -310,6 +311,12 @@ impl From<&Procedure> for ResourceTarget {
 impl From<&ServerTemplate> for ResourceTarget {
   fn from(server_template: &ServerTemplate) -> Self {
     Self::ServerTemplate(server_template.id.clone())
+  }
+}
+
+impl From<&ResourceSync> for ResourceTarget {
+  fn from(resource_sync: &ResourceSync) -> Self {
+    Self::ResourceSync(resource_sync.id.clone())
   }
 }
 

--- a/client/core/rs/src/entities/user.rs
+++ b/client/core/rs/src/entities/user.rs
@@ -1,9 +1,11 @@
-use std::sync::OnceLock;
+use std::{collections::HashMap, sync::OnceLock};
 
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
 use crate::entities::{MongoId, I64};
+
+use super::{permission::PermissionLevel, update::ResourceTargetVariant};
 
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -47,6 +49,10 @@ pub struct User {
   #[serde(default)]
   pub create_build_permissions: bool,
 
+  /// Give the user elevated permissions on all resources of a certain type
+  #[serde(default)]
+  pub all: HashMap<ResourceTargetVariant, PermissionLevel>,
+
   /// The user-type specific config.
   pub config: UserConfig,
 
@@ -54,25 +60,9 @@ pub struct User {
   #[serde(default)]
   pub last_update_view: I64,
 
-  /// Recently viewed server ids
+  /// Recently viewed ids
   #[serde(default)]
-  pub recent_servers: Vec<String>,
-
-  /// Recently viewed deployment ids
-  #[serde(default)]
-  pub recent_deployments: Vec<String>,
-
-  /// Recently viewed build ids
-  #[serde(default)]
-  pub recent_builds: Vec<String>,
-
-  /// Recently viewed repo ids
-  #[serde(default)]
-  pub recent_repos: Vec<String>,
-
-  /// Recently viewed procedure ids
-  #[serde(default)]
-  pub recent_procedures: Vec<String>,
+  pub recents: HashMap<ResourceTargetVariant, Vec<String>>,
 
   #[serde(default)]
   pub updated_at: I64,

--- a/client/core/rs/src/entities/user.rs
+++ b/client/core/rs/src/entities/user.rs
@@ -5,7 +5,7 @@ use typeshare::typeshare;
 
 use crate::entities::{MongoId, I64};
 
-use super::{permission::PermissionLevel, update::ResourceTargetVariant};
+use super::update::ResourceTargetVariant;
 
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -48,10 +48,6 @@ pub struct User {
   /// Whether the user has permission to create builds
   #[serde(default)]
   pub create_build_permissions: bool,
-
-  /// Give the user elevated permissions on all resources of a certain type
-  #[serde(default)]
-  pub all: HashMap<ResourceTargetVariant, PermissionLevel>,
 
   /// The user-type specific config.
   pub config: UserConfig,

--- a/client/core/rs/src/entities/user.rs
+++ b/client/core/rs/src/entities/user.rs
@@ -5,7 +5,9 @@ use typeshare::typeshare;
 
 use crate::entities::{MongoId, I64};
 
-use super::update::ResourceTargetVariant;
+use super::{
+  permission::PermissionLevel, update::ResourceTargetVariant,
+};
 
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -59,6 +61,10 @@ pub struct User {
   /// Recently viewed ids
   #[serde(default)]
   pub recents: HashMap<ResourceTargetVariant, Vec<String>>,
+
+  /// Give the user elevated permissions on all resources of a certain type
+  #[serde(default)]
+  pub all: HashMap<ResourceTargetVariant, PermissionLevel>,
 
   #[serde(default)]
   pub updated_at: I64,

--- a/client/core/rs/src/entities/user_group.rs
+++ b/client/core/rs/src/entities/user_group.rs
@@ -1,8 +1,16 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use typeshare::typeshare;
 
-use super::{MongoId, I64};
+use super::{permission::PermissionLevel, update::ResourceTargetVariant, MongoId, I64};
 
+/// Permission users at the group level.
+/// 
+/// All users that are part of a group inherit the group's permissions.
+/// A user can be a part of multiple groups. A user's permission on a particular resource
+/// will be resolved to be the maximum permission level between the user's own permissions and
+/// any groups they are a part of.
 #[typeshare]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[cfg_attr(
@@ -21,13 +29,19 @@ pub struct UserGroup {
   )]
   pub id: MongoId,
 
+  /// A name for the user group
   #[cfg_attr(feature = "mongo", unique_index)]
   pub name: String,
 
-  /// User ids
+  /// User ids of group members
   #[cfg_attr(feature = "mongo", index)]
   pub users: Vec<String>,
 
+  /// Give the user group elevated permissions on all resources of a certain type
+  #[serde(default)]
+  pub all: HashMap<ResourceTargetVariant, PermissionLevel>,
+
+  /// Unix time (ms) when user group last updated
   #[serde(default)]
   pub updated_at: I64,
 }

--- a/client/core/ts/src/responses.ts
+++ b/client/core/ts/src/responses.ts
@@ -158,6 +158,7 @@ export type WriteResponses = {
   AddUserToUserGroup: Types.UserGroup;
   RemoveUserFromUserGroup: Types.UserGroup;
   SetUsersInUserGroup: Types.UserGroup;
+  SetUserGroupResourceBasePermission: Types.UserGroup;
 
   // ==== PERMISSIONS ====
   UpdateUserBasePermissions: Types.UpdateUserBasePermissionsResponse;

--- a/client/core/ts/src/responses.ts
+++ b/client/core/ts/src/responses.ts
@@ -158,10 +158,10 @@ export type WriteResponses = {
   AddUserToUserGroup: Types.UserGroup;
   RemoveUserFromUserGroup: Types.UserGroup;
   SetUsersInUserGroup: Types.UserGroup;
-  SetUserGroupResourceBasePermission: Types.UserGroup;
 
   // ==== PERMISSIONS ====
   UpdateUserBasePermissions: Types.UpdateUserBasePermissionsResponse;
+  UpdatePermissionOnResourceType: Types.UpdatePermissionOnResourceTypeResponse;
   UpdatePermissionOnTarget: Types.UpdatePermissionOnTargetResponse;
 
   // ==== DESCRIPTION ====

--- a/client/core/ts/src/responses.ts
+++ b/client/core/ts/src/responses.ts
@@ -23,6 +23,7 @@ export type ReadResponses = {
   // ==== USER ====
   GetUsername: Types.GetUsernameResponse;
   GetPermissionLevel: Types.GetPermissionLevelResponse;
+  FindUser: Types.FindUserResponse;
   ListUsers: Types.ListUsersResponse;
   ListApiKeys: Types.ListApiKeysResponse;
   ListApiKeysForServiceUser: Types.ListApiKeysForServiceUserResponse;

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -23,6 +23,18 @@ export interface MongoIdObj {
 
 export type MongoId = MongoIdObj;
 
+/** The levels of permission that a User or UserGroup can have on a resource. */
+export enum PermissionLevel {
+	/** No permissions. */
+	None = "None",
+	/** Can see the rousource */
+	Read = "Read",
+	/** Can execute actions on the resource */
+	Execute = "Execute",
+	/** Can update the resource configuration */
+	Write = "Write",
+}
+
 export type UserConfig = 
 	/** User that logs in with username / password */
 	| { type: "Local", data: {
@@ -62,20 +74,14 @@ export interface User {
 	create_server_permissions?: boolean;
 	/** Whether the user has permission to create builds */
 	create_build_permissions?: boolean;
+	/** Give the user elevated permissions on all resources of a certain type */
+	all?: Record<ResourceTarget["type"], PermissionLevel>;
 	/** The user-type specific config. */
 	config: UserConfig;
 	/** When the user last opened updates dropdown. */
 	last_update_view?: I64;
-	/** Recently viewed server ids */
-	recent_servers?: string[];
-	/** Recently viewed deployment ids */
-	recent_deployments?: string[];
-	/** Recently viewed build ids */
-	recent_builds?: string[];
-	/** Recently viewed repo ids */
-	recent_repos?: string[];
-	/** Recently viewed procedure ids */
-	recent_procedures?: string[];
+	/** Recently viewed ids */
+	recents?: Record<ResourceTarget["type"], string[]>;
 	updated_at?: I64;
 }
 
@@ -202,8 +208,6 @@ export type AlertData =
 	name: string;
 	/** The version that failed to build */
 	version: Version;
-	/** The reason build failed */
-	err?: Log;
 }};
 
 /** Representation of an alert in the system. */
@@ -696,18 +700,6 @@ export type UserTarget =
 	| { type: "User", id: string }
 	/** UserGroup Id */
 	| { type: "UserGroup", id: string };
-
-/** The levels of permission that a User or UserGroup can have on a resource. */
-export enum PermissionLevel {
-	/** No permissions. */
-	None = "None",
-	/** Can see the rousource */
-	Read = "Read",
-	/** Can execute actions on the resource */
-	Execute = "Execute",
-	/** Can update the resource configuration */
-	Write = "Write",
-}
 
 /** Representation of a User or UserGroups permission on a resource. */
 export interface Permission {
@@ -1462,6 +1454,14 @@ export type ListApiKeysForServiceUserResponse = ApiKey[];
 
 export type ListUsersResponse = User[];
 
+/**
+ * Permission users at the group level.
+ * 
+ * All users that are part of a group inherit the group's permissions.
+ * A user can be a part of multiple groups. A user's permission on a particular resource
+ * will be resolved to be the maximum permission level between the user's own permissions and
+ * any groups they are a part of.
+ */
 export interface UserGroup {
 	/**
 	 * The Mongo ID of the UserGroup.
@@ -1469,9 +1469,13 @@ export interface UserGroup {
 	 * `{ "_id": { "$oid": "..." }, ...(rest of serialized User) }`
 	 */
 	_id?: MongoId;
+	/** A name for the user group */
 	name: string;
-	/** User ids */
+	/** User ids of group members */
 	users: string[];
+	/** Give the user group elevated permissions on all resources of a certain type */
+	all?: Record<ResourceTarget["type"], PermissionLevel>;
+	/** Unix time (ms) when user group last updated */
 	updated_at?: I64;
 }
 

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -1452,6 +1452,8 @@ export type ListApiKeysResponse = ApiKey[];
 
 export type ListApiKeysForServiceUserResponse = ApiKey[];
 
+export type FindUserResponse = User;
+
 export type ListUsersResponse = User[];
 
 /**
@@ -2934,19 +2936,29 @@ export interface ListApiKeys {
 }
 
 /**
- * Gets list of api keys for the user at ID.
  * **Admin only.**
+ * Gets list of api keys for the user.
  * Will still fail if you call for a user_id that isn't a service user.
  * Response: [ListApiKeysForServiceUserResponse]
  */
 export interface ListApiKeysForServiceUser {
-	/** The id of the user. */
-	user_id: string;
+	/** Id or username */
+	user: string;
 }
 
 /**
- * Gets list of monitor users.
  * **Admin only.**
+ * Find a user.
+ * Response: [FindUserResponse]
+ */
+export interface FindUser {
+	/** Id or username */
+	user: string;
+}
+
+/**
+ * **Admin only.**
+ * Gets list of monitor users.
  * Response: [ListUsersResponse]
  */
 export interface ListUsers {
@@ -4108,6 +4120,7 @@ export type ReadRequest =
 	| { type: "GetAvailableAwsEcrLabels", params: GetAvailableAwsEcrLabels }
 	| { type: "GetUsername", params: GetUsername }
 	| { type: "GetPermissionLevel", params: GetPermissionLevel }
+	| { type: "FindUser", params: FindUser }
 	| { type: "ListUsers", params: ListUsers }
 	| { type: "ListApiKeys", params: ListApiKeys }
 	| { type: "ListApiKeysForServiceUser", params: ListApiKeysForServiceUser }

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -23,18 +23,6 @@ export interface MongoIdObj {
 
 export type MongoId = MongoIdObj;
 
-/** The levels of permission that a User or UserGroup can have on a resource. */
-export enum PermissionLevel {
-	/** No permissions. */
-	None = "None",
-	/** Can see the rousource */
-	Read = "Read",
-	/** Can execute actions on the resource */
-	Execute = "Execute",
-	/** Can update the resource configuration */
-	Write = "Write",
-}
-
 export type UserConfig = 
 	/** User that logs in with username / password */
 	| { type: "Local", data: {
@@ -57,6 +45,18 @@ export type UserConfig =
 
 export type I64 = number;
 
+/** The levels of permission that a User or UserGroup can have on a resource. */
+export enum PermissionLevel {
+	/** No permissions. */
+	None = "None",
+	/** Can see the rousource */
+	Read = "Read",
+	/** Can execute actions on the resource */
+	Execute = "Execute",
+	/** Can update the resource configuration */
+	Write = "Write",
+}
+
 export interface User {
 	/**
 	 * The Mongo ID of the User.
@@ -74,14 +74,14 @@ export interface User {
 	create_server_permissions?: boolean;
 	/** Whether the user has permission to create builds */
 	create_build_permissions?: boolean;
-	/** Give the user elevated permissions on all resources of a certain type */
-	all?: Record<ResourceTarget["type"], PermissionLevel>;
 	/** The user-type specific config. */
 	config: UserConfig;
 	/** When the user last opened updates dropdown. */
 	last_update_view?: I64;
 	/** Recently viewed ids */
 	recents?: Record<ResourceTarget["type"], string[]>;
+	/** Give the user elevated permissions on all resources of a certain type */
+	all?: Record<ResourceTarget["type"], PermissionLevel>;
 	updated_at?: I64;
 }
 

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -3749,6 +3749,19 @@ export interface SetUsersInUserGroup {
 	users: string[];
 }
 
+/**
+ * **Admin only.** Set the user group base permission levels on resource type
+ * Response: [UserGroup]
+ */
+export interface SetUserGroupResourceBasePermission {
+	/** Id or name. */
+	user_group: string;
+	/** The resource type: eg. Server, Build, Deployment, etc. */
+	resource_type: ResourceTarget["type"];
+	/** The base permission level. */
+	level: PermissionLevel;
+}
+
 /** **Admin only.** Create variable. Response: [Variable]. */
 export interface CreateVariable {
 	/** The name of the variable to create. */
@@ -4196,6 +4209,7 @@ export type WriteRequest =
 	| { type: "AddUserToUserGroup", params: AddUserToUserGroup }
 	| { type: "RemoveUserFromUserGroup", params: RemoveUserFromUserGroup }
 	| { type: "SetUsersInUserGroup", params: SetUsersInUserGroup }
+	| { type: "SetUserGroupResourceBasePermission", params: SetUserGroupResourceBasePermission }
 	| { type: "UpdateUserBasePermissions", params: UpdateUserBasePermissions }
 	| { type: "UpdatePermissionOnTarget", params: UpdatePermissionOnTarget }
 	| { type: "UpdateDescription", params: UpdateDescription }

--- a/client/core/ts/src/types.ts
+++ b/client/core/ts/src/types.ts
@@ -1532,6 +1532,8 @@ export type UpdateDescriptionResponse = NoData;
 
 export type UpdatePermissionOnTargetResponse = NoData;
 
+export type UpdatePermissionOnResourceTypeResponse = NoData;
+
 export type UpdateUserBasePermissionsResponse = NoData;
 
 export type CreateProcedureResponse = Procedure;
@@ -3305,7 +3307,7 @@ export interface UpdateDescription {
 }
 
 /**
- * Update a user or user groups permission on a resource.
+ * **Admin only.** Update a user or user groups permission on a resource.
  * Response: [NoData].
  */
 export interface UpdatePermissionOnTarget {
@@ -3318,7 +3320,20 @@ export interface UpdatePermissionOnTarget {
 }
 
 /**
- * Update a user's "base" permissions, eg. "enabled".
+ * **Admin only.** Update a user or user groups base permission level on a resource type.
+ * Response: [NoData].
+ */
+export interface UpdatePermissionOnResourceType {
+	/** Specify the user or user group. */
+	user_target: UserTarget;
+	/** The resource type: eg. Server, Build, Deployment, etc. */
+	resource_type: ResourceTarget["type"];
+	/** The base permission level. */
+	permission: PermissionLevel;
+}
+
+/**
+ * **Admin only.** Update a user's "base" permissions, eg. "enabled".
  * Response: [NoData].
  */
 export interface UpdateUserBasePermissions {
@@ -3747,19 +3762,6 @@ export interface SetUsersInUserGroup {
 	user_group: string;
 	/** The user ids or usernames to hard set as the group's users. */
 	users: string[];
-}
-
-/**
- * **Admin only.** Set the user group base permission levels on resource type
- * Response: [UserGroup]
- */
-export interface SetUserGroupResourceBasePermission {
-	/** Id or name. */
-	user_group: string;
-	/** The resource type: eg. Server, Build, Deployment, etc. */
-	resource_type: ResourceTarget["type"];
-	/** The base permission level. */
-	level: PermissionLevel;
 }
 
 /** **Admin only.** Create variable. Response: [Variable]. */
@@ -4209,8 +4211,8 @@ export type WriteRequest =
 	| { type: "AddUserToUserGroup", params: AddUserToUserGroup }
 	| { type: "RemoveUserFromUserGroup", params: RemoveUserFromUserGroup }
 	| { type: "SetUsersInUserGroup", params: SetUsersInUserGroup }
-	| { type: "SetUserGroupResourceBasePermission", params: SetUserGroupResourceBasePermission }
 	| { type: "UpdateUserBasePermissions", params: UpdateUserBasePermissions }
+	| { type: "UpdatePermissionOnResourceType", params: UpdatePermissionOnResourceType }
 	| { type: "UpdatePermissionOnTarget", params: UpdatePermissionOnTarget }
 	| { type: "UpdateDescription", params: UpdateDescription }
 	| { type: "CreateServer", params: CreateServer }

--- a/docsite/docs/sync-resources.md
+++ b/docsite/docs/sync-resources.md
@@ -175,3 +175,23 @@ config.repo = "mbecker20/monitor"
 config.on_pull.path = "."
 config.on_pull.command = "/root/.cargo/bin/cargo build -p monitor_periphery --release && cp ./target/release/periphery /root/periphery"
 ```
+
+## User Group:
+
+- [UserGroup schema](https://docs.rs/monitor_client/latest/monitor_client/entities/toml/struct.UserGroupToml.html)
+
+```toml
+[[user_group]]
+name = "groupo"
+users = ["mbecker20", "karamvirsingh98"]
+# Attach base level of Execute on all builds
+all.Build = "Execute"
+all.Alerter = "Write"
+permissions = [
+  # Attach permissions to specific resources by name
+  { target.type = "Repo", target.id = "monitor-periphery", level = "Execute" },
+  # Attach permissions to many resources with name matching regex (this uses '^(.+)-(.+)$' as regex expression)
+  { target.type = "Server", target.id = "$reg|^(.+)-(.+)$|", level = "Read" },
+  { target.type = "Deployment", target.id = "$reg|^immich|", level = "Execute" },
+]
+```

--- a/docsite/docs/sync-resources.md
+++ b/docsite/docs/sync-resources.md
@@ -193,7 +193,7 @@ permissions = [
   # Attach permissions to specific resources by name
   { target.type = "Repo", target.id = "monitor-periphery", level = "Execute" },
   # Attach permissions to many resources with name matching regex (this uses '^(.+)-(.+)$' as regex expression)
-  { target.type = "Server", target.id = "$reg|^(.+)-(.+)$|", level = "Read" },
-  { target.type = "Deployment", target.id = "$reg|^immich|", level = "Execute" },
+  { target.type = "Server", target.id = "\\^(.+)-(.+)$\\", level = "Read" },
+  { target.type = "Deployment", target.id = "\\^immich\\", level = "Execute" },
 ]
 ```

--- a/docsite/docs/sync-resources.md
+++ b/docsite/docs/sync-resources.md
@@ -12,7 +12,9 @@ The UI will display the computed sync actions and only execute them upon manual 
 Or the sync execution Github webhook may be configured on the Github repo to
 automatically execute syncs upon pushes to the configured branch.
 
-## Example file:
+## Server:
+
+- [Server config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/server/struct.ServerConfig.html)
 
 ```toml
 [[server]] # Declare a new server
@@ -21,7 +23,30 @@ description = "the main mogh server"
 tags = ["monitor"]
 config.address = "http://localhost:8120"
 config.region = "AshburnDc1"
-config.enabled = true
+config.enabled = true # default: false
+```
+
+## Builder and build:
+
+- [Builder config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/builder/struct.BuilderConfig.html)
+- [Build config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/build/struct.BuildConfig.html)
+
+```toml
+[[builder]] # Declare a builder
+name = "builder-01"
+tags = []
+config.type = "Aws"
+config.params.region = "us-east-2"
+config.params.ami_id = "ami-0e9bd154667944680"
+# These things come from your specific setup
+config.params.subnet_id = "subnet-xxxxxxxxxxxxxxxxxx"
+config.params.key_pair_name = "xxxxxxxx"
+config.params.assign_public_ip = true
+config.params.use_public_ip = true
+config.params.security_group_ids = [
+  "sg-xxxxxxxxxxxxxxxxxx",
+  "sg-xxxxxxxxxxxxxxxxxx"
+]
 
 ##
 
@@ -40,9 +65,13 @@ config.labels = """
 org.opencontainers.image.source = https://github.com/mbecker20/test_logger
 org.opencontainers.image.description = Logs randomly at INFO, WARN, ERROR levels to test logging setups
 org.opencontainers.image.licenses = GPL-3.0"""
+```
 
-##
+## Deployments:
 
+- [Deployment config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/deployment/struct.DeploymentConfig.html)
+
+```toml
 [[variable]] # Declare variables
 name = "OTLP_ENDPOINT"
 value = "http://localhost:4317"
@@ -94,21 +123,13 @@ VARIABLE_1 = value_1
 VARIABLE_2 = value_2"""
 # Set Docker labels
 config.labels = "deployment.type = logger"
+```
 
-##
+## Procedure:
 
-[[repo]]
-name = "monitor-periphery"
-description = "Builds new versions of the periphery binary. Requires Rust installed on the host."
-tags = ["monitor"]
-config.server_id = "server-01"
-config.repo = "mbecker20/monitor"
-# Run an action after the repo is pulled
-config.on_pull.path = "."
-config.on_pull.command = "/root/.cargo/bin/cargo build -p monitor_periphery --release && cp ./target/release/periphery /root/periphery"
+- [Procedure config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/procedure/struct.ProcedureConfig.html)
 
-##
-
+```toml
 [[procedure]]
 name = "test-procedure"
 description = "Do some things in a specific order"
@@ -137,22 +158,20 @@ enabled = true
 executions = [
   { execution.type = "Deploy", execution.params.deployment = "test-logger-02", enabled = true }
 ]
+```
 
-##
+## Repo:
 
-[[builder]] # Declare a builder
-name = "builder-01"
-tags = []
-config.type = "Aws"
-config.params.region = "us-east-2"
-config.params.ami_id = "ami-0e9bd154667944680"
-# These things come from your specific setup
-config.params.subnet_id = "subnet-xxxxxxxxxxxxxxxxxx"
-config.params.key_pair_name = "xxxxxxxx"
-config.params.assign_public_ip = true
-config.params.use_public_ip = true
-config.params.security_group_ids = [
-  "sg-xxxxxxxxxxxxxxxxxx",
-  "sg-xxxxxxxxxxxxxxxxxx"
-]
+- [Repo config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/repo/struct.RepoConfig.html)
+
+```toml
+[[repo]]
+name = "monitor-periphery"
+description = "Builds new versions of the periphery binary. Requires Rust installed on the host."
+tags = ["monitor"]
+config.server_id = "server-01"
+config.repo = "mbecker20/monitor"
+# Run an action after the repo is pulled
+config.on_pull.path = "."
+config.on_pull.command = "/root/.cargo/bin/cargo build -p monitor_periphery --release && cp ./target/release/periphery /root/periphery"
 ```

--- a/docsite/docs/sync-resources.md
+++ b/docsite/docs/sync-resources.md
@@ -12,7 +12,9 @@ The UI will display the computed sync actions and only execute them upon manual 
 Or the sync execution Github webhook may be configured on the Github repo to
 automatically execute syncs upon pushes to the configured branch.
 
-## Server:
+## Example Declarations
+
+### Server
 
 - [Server config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/server/struct.ServerConfig.html)
 
@@ -26,7 +28,7 @@ config.region = "AshburnDc1"
 config.enabled = true # default: false
 ```
 
-## Builder and build:
+### Builder and build
 
 - [Builder config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/builder/struct.BuilderConfig.html)
 - [Build config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/build/struct.BuildConfig.html)
@@ -67,7 +69,7 @@ org.opencontainers.image.description = Logs randomly at INFO, WARN, ERROR levels
 org.opencontainers.image.licenses = GPL-3.0"""
 ```
 
-## Deployments:
+### Deployments
 
 - [Deployment config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/deployment/struct.DeploymentConfig.html)
 
@@ -125,7 +127,7 @@ VARIABLE_2 = value_2"""
 config.labels = "deployment.type = logger"
 ```
 
-## Procedure:
+### Procedure
 
 - [Procedure config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/procedure/struct.ProcedureConfig.html)
 
@@ -160,7 +162,7 @@ executions = [
 ]
 ```
 
-## Repo:
+### Repo
 
 - [Repo config schema](https://docs.rs/monitor_client/latest/monitor_client/entities/repo/struct.RepoConfig.html)
 
@@ -176,7 +178,7 @@ config.on_pull.path = "."
 config.on_pull.command = "/root/.cargo/bin/cargo build -p monitor_periphery --release && cp ./target/release/periphery /root/periphery"
 ```
 
-## User Group:
+### User Group:
 
 - [UserGroup schema](https://docs.rs/monitor_client/latest/monitor_client/entities/toml/struct.UserGroupToml.html)
 

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -408,6 +408,7 @@ export const SystemCommand = ({
             value={value?.command}
             onUpdate={(command) => set({ ...(value || {}), command })}
             triggerClassName="w-[200px] lg:w-[300px] xl:w-[400px]"
+            disabled={disabled}
           />
         </div>
       </div>

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useInvalidate, useRead, useWrite } from "@lib/hooks";
+import { useRead } from "@lib/hooks";
 import { Types } from "@monitor/client";
 import {
   Select,
@@ -19,7 +19,7 @@ import {
   SearchX,
 } from "lucide-react";
 import { ReactNode, useState } from "react";
-import { cn, filterBySplit, RESOURCE_TARGETS } from "@lib/utils";
+import { cn, filterBySplit } from "@lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -39,8 +39,6 @@ import {
   CommandItem,
   CommandList,
 } from "@ui/command";
-import { useToast } from "@ui/use-toast";
-import { Section } from "@components/layouts";
 
 export const ConfigItem = ({
   label,
@@ -799,99 +797,5 @@ export const PermissionLevelSelector = ({
         ))}
       </SelectContent>
     </Select>
-  );
-};
-
-export const UserTargetPermissionsOnResourceTypes = ({
-  user_target,
-}: {
-  user_target: Types.UserTarget;
-}) => {
-  const { toast } = useToast();
-  const inv = useInvalidate();
-
-  const { mutate } = useWrite("UpdatePermissionOnResourceType", {
-    onSuccess: () => {
-      toast({ title: "Updated permissions on target" });
-      if (user_target.type === "User") {
-        inv(["FindUser", { user: user_target.id }]);
-      } else if (user_target.type === "UserGroup") {
-        inv(["GetUserGroup", { user_group: user_target.id }]);
-      }
-    },
-  });
-
-  const update = (resource_type, permission) =>
-    mutate({ user_target, resource_type, permission });
-
-  if (user_target.type === "User") {
-    return (
-      <UserPermissionsOnResourceType user_id={user_target.id} update={update} />
-    );
-  } else if (user_target.type === "UserGroup") {
-    return (
-      <UserGroupPermissionsOnResourceType
-        group_id={user_target.id}
-        update={update}
-      />
-    );
-  }
-};
-
-const UserPermissionsOnResourceType = ({
-  user_id,
-  update,
-}: {
-  user_id: string;
-  update: (
-    resource_type: Types.ResourceTarget["type"],
-    permission: Types.PermissionLevel
-  ) => void;
-}) => {
-  const user = useRead("FindUser", { user: user_id }).data;
-  return <PermissionsOnResourceType all={user?.all} update={update} />;
-};
-
-const UserGroupPermissionsOnResourceType = ({
-  group_id,
-  update,
-}: {
-  group_id: string;
-  update: (
-    resource_type: Types.ResourceTarget["type"],
-    permission: Types.PermissionLevel
-  ) => void;
-}) => {
-  const group = useRead("GetUserGroup", { user_group: group_id }).data;
-  return <PermissionsOnResourceType all={group?.all} update={update} />;
-};
-
-const PermissionsOnResourceType = ({
-  all,
-  update,
-}: {
-  all: Types.User["all"];
-  update: (
-    resource_type: Types.ResourceTarget["type"],
-    permission: Types.PermissionLevel
-  ) => void;
-}) => {
-  return (
-    <Section title="Base Permissions">
-      <div className="p-1 grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
-        {RESOURCE_TARGETS.map((type) => {
-          const level = all?.[type] ?? Types.PermissionLevel.None;
-          return (
-            <div className="flex items-center justify-between w-[270px]">
-              {type}:
-              <PermissionLevelSelector
-                level={level}
-                onSelect={(level) => update(type, level)}
-              />
-            </div>
-          );
-        })}
-      </div>
-    </Section>
   );
 };

--- a/frontend/src/components/config/util.tsx
+++ b/frontend/src/components/config/util.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useRead, useWrite } from "@lib/hooks";
+import { useInvalidate, useRead, useWrite } from "@lib/hooks";
 import { Types } from "@monitor/client";
 import {
   Select,
@@ -807,10 +807,16 @@ export const UserTargetPermissionsOnResourceTypes = ({
   user_target: Types.UserTarget;
 }) => {
   const { toast } = useToast();
+  const inv = useInvalidate();
 
   const { mutate } = useWrite("UpdatePermissionOnResourceType", {
     onSuccess: () => {
       toast({ title: "Updated permissions on target" });
+      if (user_target.type === "User") {
+        inv(["FindUser", { user: user_target.id }]);
+      } else if (user_target.type === "UserGroup") {
+        inv(["GetUserGroup", { user_group: user_target.id }]);
+      }
     },
   });
 
@@ -871,11 +877,11 @@ const PermissionsOnResourceType = ({
 }) => {
   return (
     <Section title="Base Permissions">
-      <div className="flex gap-4 items-center flex-wrap">
+      <div className="p-1 grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
         {RESOURCE_TARGETS.map((type) => {
           const level = all?.[type] ?? Types.PermissionLevel.None;
           return (
-            <div className="flex gap-2 items-center">
+            <div className="flex items-center justify-between w-[270px]">
               {type}:
               <PermissionLevelSelector
                 level={level}

--- a/frontend/src/components/layouts.tsx
+++ b/frontend/src/components/layouts.tsx
@@ -130,7 +130,7 @@ export const Section = ({
   children,
 }: SectionProps) => (
   <div className="flex flex-col gap-4 max-w-[calc(100vw-100px)] lg:max-w-[calc(100vw-300px)] overflow-x-auto">
-    <div className="flex flex-wrap gap-2 items-start justify-between">
+    <div className="flex flex-wrap gap-2 items-start justify-between py-1">
       {title || icon ? (
         <div className="flex items-center gap-2 text-muted-foreground">
           {icon}

--- a/frontend/src/components/resources/alerter/config/resources.tsx
+++ b/frontend/src/components/resources/alerter/config/resources.tsx
@@ -34,6 +34,7 @@ export const ResourcesConfig = ({
   const servers = useRead("ListServers", {}).data ?? [];
   const deployments = useRead("ListDeployments", {}).data ?? [];
   const builds = useRead("ListBuilds", {}).data ?? [];
+  const syncs = useRead("ListResourceSyncs", {}).data ?? [];
   const all_resources = [
     ...servers.map((server) => {
       return {
@@ -62,6 +63,16 @@ export const ResourcesConfig = ({
       id: build.id,
       name: build.name.toLowerCase(),
       enabled: resources.find((r) => r.type === "Build" && r.id === build.id)
+        ? true
+        : false,
+    })),
+    ...syncs.map((sync) => ({
+      type: "ResourceSync",
+      id: sync.id,
+      name: sync.name.toLowerCase(),
+      enabled: resources.find(
+        (r) => r.type === "ResourceSync" && r.id === sync.id
+      )
         ? true
         : false,
     })),

--- a/frontend/src/components/users/hooks.ts
+++ b/frontend/src/components/users/hooks.ts
@@ -13,6 +13,8 @@ export const useUserTargetPermissions = (user_target: Types.UserTarget) => {
   const procedures = useRead("ListProcedures", {}).data;
   const builders = useRead("ListBuilders", {}).data;
   const alerters = useRead("ListAlerters", {}).data;
+  const templates = useRead("ListServerTemplates", {}).data;
+  const syncs = useRead("ListResourceSyncs", {}).data;
   const perms: (Types.Permission & { name: string })[] = [];
   addPerms(user_target, permissions, "Server", servers, perms);
   addPerms(user_target, permissions, "Deployment", deployments, perms);
@@ -21,6 +23,8 @@ export const useUserTargetPermissions = (user_target: Types.UserTarget) => {
   addPerms(user_target, permissions, "Procedure", procedures, perms);
   addPerms(user_target, permissions, "Builder", builders, perms);
   addPerms(user_target, permissions, "Alerter", alerters, perms);
+  addPerms(user_target, permissions, "ServerTemplate", templates, perms);
+  addPerms(user_target, permissions, "ResourceSync", syncs, perms);
   return perms;
 };
 

--- a/frontend/src/components/users/permissions-table.tsx
+++ b/frontend/src/components/users/permissions-table.tsx
@@ -43,7 +43,7 @@ export const PermissionsTable = ({
   });
   return (
     <Section
-      title="Permissions"
+      title="Specific Permissions"
       actions={
         <div className="flex gap-6 items-center">
           <Input

--- a/frontend/src/components/users/permissions-table.tsx
+++ b/frontend/src/components/users/permissions-table.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@ui/select";
+import { PermissionLevelSelector } from "@components/config/util";
 
 export const PermissionsTable = ({
   user_target,
@@ -163,31 +164,16 @@ export const PermissionsTable = ({
               <SortableHeader column={column} title="Level" />
             ),
             cell: ({ row: { original: permission } }) => (
-              <Select
-                value={permission.level}
-                onValueChange={(value) =>
+              <PermissionLevelSelector
+                level={permission.level ?? Types.PermissionLevel.None}
+                onSelect={(value) =>
                   mutate({
                     ...permission,
                     user_target,
-                    permission: value as Types.PermissionLevel,
+                    permission: value,
                   })
                 }
-              >
-                <SelectTrigger className="w-32 capitalize">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="w-32">
-                  {Object.keys(Types.PermissionLevel).map((permission) => (
-                    <SelectItem
-                      value={permission}
-                      key={permission}
-                      className="capitalize"
-                    >
-                      {permission}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              />
             ),
           },
         ]}

--- a/frontend/src/components/users/resource-type-permissions.tsx
+++ b/frontend/src/components/users/resource-type-permissions.tsx
@@ -1,0 +1,100 @@
+import { PermissionLevelSelector } from "@components/config/util";
+import { Section } from "@components/layouts";
+import { useInvalidate, useRead, useWrite } from "@lib/hooks";
+import { RESOURCE_TARGETS } from "@lib/utils";
+import { Types } from "@monitor/client";
+import { useToast } from "@ui/use-toast";
+
+export const UserTargetPermissionsOnResourceTypes = ({
+  user_target,
+}: {
+  user_target: Types.UserTarget;
+}) => {
+  const { toast } = useToast();
+  const inv = useInvalidate();
+
+  const { mutate } = useWrite("UpdatePermissionOnResourceType", {
+    onSuccess: () => {
+      toast({ title: "Updated permissions on target" });
+      if (user_target.type === "User") {
+        inv(["FindUser", { user: user_target.id }]);
+      } else if (user_target.type === "UserGroup") {
+        inv(["GetUserGroup", { user_group: user_target.id }]);
+      }
+    },
+  });
+
+  const update = (resource_type, permission) =>
+    mutate({ user_target, resource_type, permission });
+
+  if (user_target.type === "User") {
+    return (
+      <UserPermissionsOnResourceType user_id={user_target.id} update={update} />
+    );
+  } else if (user_target.type === "UserGroup") {
+    return (
+      <UserGroupPermissionsOnResourceType
+        group_id={user_target.id}
+        update={update}
+      />
+    );
+  }
+};
+
+const UserPermissionsOnResourceType = ({
+  user_id,
+  update,
+}: {
+  user_id: string;
+  update: (
+    resource_type: Types.ResourceTarget["type"],
+    permission: Types.PermissionLevel
+  ) => void;
+}) => {
+  const user = useRead("FindUser", { user: user_id }).data;
+  return <PermissionsOnResourceType all={user?.all} update={update} />;
+};
+
+const UserGroupPermissionsOnResourceType = ({
+  group_id,
+  update,
+}: {
+  group_id: string;
+  update: (
+    resource_type: Types.ResourceTarget["type"],
+    permission: Types.PermissionLevel
+  ) => void;
+}) => {
+  const group = useRead("GetUserGroup", { user_group: group_id }).data;
+  return <PermissionsOnResourceType all={group?.all} update={update} />;
+};
+
+const PermissionsOnResourceType = ({
+  all,
+  update,
+}: {
+  all: Types.User["all"];
+  update: (
+    resource_type: Types.ResourceTarget["type"],
+    permission: Types.PermissionLevel
+  ) => void;
+}) => {
+  return (
+    <Section title="Base Permissions">
+      <div className="p-1 grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        {RESOURCE_TARGETS.map((type) => {
+          const level = all?.[type] ?? Types.PermissionLevel.None;
+          return (
+            <div className="flex items-center justify-between w-[270px]">
+              {type}:
+              <PermissionLevelSelector
+                level={level}
+                onSelect={(level) => update(type, level)}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </Section>
+  );
+};

--- a/frontend/src/components/util.tsx
+++ b/frontend/src/components/util.tsx
@@ -348,7 +348,7 @@ export const TextUpdateMenu = ({
           <div
             className={cn(
               "text-sm text-nowrap overflow-hidden overflow-ellipsis",
-              !value && "text-muted-foreground",
+              (!value || !!disabled) && "text-muted-foreground",
               triggerClassName
             )}
           >

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -32,10 +32,7 @@ export const Dashboard = () => {
 };
 
 const ResourceRow = ({ type }: { type: UsableResource }) => {
-  const recents = useUser().data?.[`recent_${type.toLowerCase()}s`]?.slice(
-    0,
-    6
-  ) as string[] | undefined;
+  const recents = useUser().data?.recents?.[type].slice(0, 6);
   const resources = useRead(`List${type}s`, {})
     .data?.filter((r) => !recents?.includes(r.id))
     .map((r) => r.id);

--- a/frontend/src/pages/home/dashboard.tsx
+++ b/frontend/src/pages/home/dashboard.tsx
@@ -32,7 +32,7 @@ export const Dashboard = () => {
 };
 
 const ResourceRow = ({ type }: { type: UsableResource }) => {
-  const recents = useUser().data?.recents?.[type].slice(0, 6);
+  const recents = useUser().data?.recents?.[type]?.slice(0, 6);
   const resources = useRead(`List${type}s`, {})
     .data?.filter((r) => !recents?.includes(r.id))
     .map((r) => r.id);

--- a/frontend/src/pages/user-group.tsx
+++ b/frontend/src/pages/user-group.tsx
@@ -1,3 +1,4 @@
+import { UserTargetPermissionsOnResourceTypes } from "@components/config/util";
 import { ExportButton } from "@components/export";
 import { Page, Section } from "@components/layouts";
 import { PermissionsTable } from "@components/users/permissions-table";
@@ -85,6 +86,9 @@ export const UserGroupPage = () => {
           }
         />
       </Section>
+      <UserTargetPermissionsOnResourceTypes
+        user_target={{ type: "UserGroup", id: group._id?.$oid! }}
+      />
       <PermissionsTable user_target={{ type: "UserGroup", id: group_id }} />
       <div className="flex flex-col justify-end w-full gap-4">
         <div className="flex justify-end w-full">

--- a/frontend/src/pages/user-group.tsx
+++ b/frontend/src/pages/user-group.tsx
@@ -1,4 +1,4 @@
-import { UserTargetPermissionsOnResourceTypes } from "@components/config/util";
+import { UserTargetPermissionsOnResourceTypes } from "@components/users/resource-type-permissions";
 import { ExportButton } from "@components/export";
 import { Page, Section } from "@components/layouts";
 import { PermissionsTable } from "@components/users/permissions-table";

--- a/frontend/src/pages/user.tsx
+++ b/frontend/src/pages/user.tsx
@@ -1,3 +1,4 @@
+import { UserTargetPermissionsOnResourceTypes } from "@components/config/util";
 import { KeysTable } from "@components/keys/table";
 import { Page, Section } from "@components/layouts";
 import { PermissionsTable } from "@components/users/permissions-table";
@@ -85,14 +86,19 @@ export const UserPage = () => {
     >
       {user.config.type === "Service" && <ApiKeysTable user_id={user_id} />}
       {!user.admin && (
-        <PermissionsTable user_target={{ type: "User", id: user_id }} />
+        <>
+          <UserTargetPermissionsOnResourceTypes
+            user_target={{ type: "User", id: user._id?.$oid! }}
+          />
+          <PermissionsTable user_target={{ type: "User", id: user_id }} />
+        </>
       )}
     </Page>
   );
 };
 
 const ApiKeysTable = ({ user_id }: { user_id: string }) => {
-  const keys = useRead("ListApiKeysForServiceUser", { user_id }).data;
+  const keys = useRead("ListApiKeysForServiceUser", { user: user_id }).data;
   return (
     <Section
       title="Api Keys"

--- a/frontend/src/pages/user.tsx
+++ b/frontend/src/pages/user.tsx
@@ -22,14 +22,10 @@ export const UserPage = () => {
     (user) => user._id?.$oid === user_id
   );
   const { mutate } = useWrite("UpdateUserBasePermissions", {
-    onSuccess: () => inv(["ListUsers"]),
-    onError: (e) => {
-      console.log("update user permission failure", e);
-      toast({
-        title: "Failed to update user permissions",
-        description: "See console for details",
-        variant: "destructive",
-      });
+    onSuccess: () => {
+      inv(["FindUser", { user: user_id }]);
+      inv(["ListUsers"]);
+      toast({ title: "Modify user base permissions" });
     },
   });
   const enabledClass = user?.enabled ? "text-green-500" : "text-red-500";
@@ -85,7 +81,7 @@ export const UserPage = () => {
       }
     >
       {user.config.type === "Service" && <ApiKeysTable user_id={user_id} />}
-      {!user.admin && (
+      {user.enabled && !user.admin && (
         <>
           <UserTargetPermissionsOnResourceTypes
             user_target={{ type: "User", id: user._id?.$oid! }}

--- a/frontend/src/pages/user.tsx
+++ b/frontend/src/pages/user.tsx
@@ -1,4 +1,4 @@
-import { UserTargetPermissionsOnResourceTypes } from "@components/config/util";
+import { UserTargetPermissionsOnResourceTypes } from "@components/users/resource-type-permissions";
 import { KeysTable } from "@components/keys/table";
 import { Page, Section } from "@components/layouts";
 import { PermissionsTable } from "@components/users/permissions-table";
@@ -11,8 +11,9 @@ import { useInvalidate, useRead, useWrite } from "@lib/hooks";
 import { Label } from "@ui/label";
 import { Switch } from "@ui/switch";
 import { useToast } from "@ui/use-toast";
-import { Key, UserCheck, UserMinus } from "lucide-react";
-import { useParams } from "react-router-dom";
+import { Key, UserCheck, UserMinus, Users } from "lucide-react";
+import { Link, useParams } from "react-router-dom";
+import { Button } from "@ui/button";
 
 export const UserPage = () => {
   const { toast } = useToast();
@@ -83,6 +84,7 @@ export const UserPage = () => {
       {user.config.type === "Service" && <ApiKeysTable user_id={user_id} />}
       {user.enabled && !user.admin && (
         <>
+          <Groups user_id={user_id} />
           <UserTargetPermissionsOnResourceTypes
             user_target={{ type: "User", id: user._id?.$oid! }}
           />
@@ -102,6 +104,29 @@ const ApiKeysTable = ({ user_id }: { user_id: string }) => {
       actions={<CreateKeyForServiceUser user_id={user_id} />}
     >
       <KeysTable keys={keys ?? []} DeleteKey={DeleteKeyForServiceUser} />
+    </Section>
+  );
+};
+
+const Groups = ({ user_id }: { user_id: string }) => {
+  const groups = useRead("ListUserGroups", {}).data?.filter((group) =>
+    group.users.includes(user_id)
+  );
+  if (!groups || groups.length === 0) {
+    return null;
+  }
+  return (
+    <Section title="Groups">
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+        {groups.map((group) => (
+          <Link to={`/user-groups/${group._id?.$oid}`}>
+            <Button variant="link" className="flex gap-2 items-center p-0">
+              <Users className="w-4 h-4" />
+              {group.name}
+            </Button>
+          </Link>
+        ))}
+      </div>
     </Section>
   );
 };


### PR DESCRIPTION
- Configure base permissions on all resources of a specific type (Read on all servers, Execute on all builds, etc.)
      - Supported for both users and user groups
      
- UserGroups declared in ResourceSync can now use regex to match against many resources for permissioning

- See [https://docs.monitor.mogh.tech/docs/sync-resources#user-group](https://docs.monitor.mogh.tech/docs/sync-resources#user-group) for example.